### PR TITLE
Refactor and extend metadata event power

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,30 @@ n.keys
 ```
 
 ### Set the user metadata
+
+- [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md)
+- [NIP-24](https://github.com/nostr-protocol/nips/blob/master/24.md)
+
 ```ruby
-metadata = n.build_metadata_event("Mr Robot", "I walk around the city", "https://upload.wikimedia.org/wikipedia/commons/3/35/Mr_robot_photo.jpg", "mrrobot@mrrobot.com")
-#["EVENT",
-# {:pubkey=>"9be59510fa12b77340bb57e555bac716455fedf46d1a354185d4e72bd0340b6f",
-#  :created_at=>1671546067,
-#  :kind=>0,
-#  :tags=>[],
-#  :content=>"{\"name\":\"Mr Robot\",\"about\":\"I walk around the city\",\"picture\":\"https://upload.wikimedia.org/wikipedia/commons/3/35/Mr_robot_photo.jpg\",\"nip05\":\"mrrobot@mrrobot.com\"}",
-#  "id"=>"3bd77596ea999dde26689c24370dc4adfa66c33abf1b4c23bf863a516106cda2",
-#  "sig"=>"2ff752e9f3ed824e7677c41c73728315f0532f3437857774d7a50a577563f391785afd1f84bef3e3574939b14cf096380d4790375953c793504ffcf2f0467d69"}]
+metadata = n.build_metadata_event(
+  name: "@mr_robot",
+  display_name: "Mr Robot",
+  about: "I walk around the city",
+  picture: "https://upload.wikimedia.org/wikipedia/commons/3/35/Mr_robot_photo.jpg",
+  banner: "https://upload.wikimedia.org/wikipedia/commons/3/35/Mr_robot_photo.jpg",
+  nip05: "mrrobot@mrrobot.com",
+  lud16: "sendmesats@mrrobot.com",
+  website: "https://mrrobot.com"
+)
+# =>
+# ["EVENT",
+#  {:pubkey=>"9be59510fa12b77340bb57e555bac716455fedf46d1a354185d4e72bd0340b6f",
+#   :created_at=>1671546067,
+#   :kind=>0,
+#   :tags=>[],
+#   :content=> "{\"name\":\"@mr_robot\",\"display_name\":\"Mr Robot\",\"about\":\"I walk around the city\",\"picture\":\"https://upload.wikimedia.org/wikipedia/commons/3/35/Mr_robot_photo.jpg\",\"banner\":\"https://upload.wikimedia.org/wikipedia/commons/3/35/Mr_robot_photo.jpg\",\"nip05\":\"mrrobot@mrrobot.com\",\"lud16\":\"sendmesats@mrrobot.com\",\"website\":\"https://mrrobot.com\"}",
+#   "id"=>"3bd77596ea999dde26689c24370dc4adfa66c33abf1b4c23bf863a516106cda2",
+#   "sig"=>"2ff752e9f3ed824e7677c41c73728315f0532f3437857774d7a50a577563f391785afd1f84bef3e3574939b14cf096380d4790375953c793504ffcf2f0467d69"}]
 ```
 
 ### Create a post

--- a/lib/nostr_ruby.rb
+++ b/lib/nostr_ruby.rb
@@ -7,6 +7,7 @@ require 'base64'
 require 'bech32'
 require 'unicode/emoji'
 require 'websocket-client-simple'
+require 'nostr_ruby/nips/metadata_event'
 
 # * Ruby library to interact with the Nostr protocol
 
@@ -101,8 +102,8 @@ class Nostr
     message = Array(serialized_event_sha256).pack('H*')
     event_signature = Schnorr.sign(message, private_key).encode.unpack('H*')[0]
 
-    event['id'] = serialized_event_sha256
-    event['sig'] = event_signature
+    event[:id] = serialized_event_sha256
+    event[:sig] = event_signature
     event
   end
 
@@ -115,19 +116,12 @@ class Nostr
     ['EVENT', event]
   end
 
-  def build_metadata_event(name, about, picture, nip05)
-    data = {}
-    data[:name] = name if name
-    data[:about] = about if about
-    data[:picture] = picture if picture
-    data[:nip05] = nip05 if nip05
-    event = {
-      "pubkey": @public_key,
-      "created_at": Time.now.utc.to_i,
-      "kind": 0,
-      "tags": [],
-      "content": data.to_json
-    }
+  # @see {Struto::Nips::MetadataEvent}
+  def build_metadata_event(metadata = {})
+    instance = NostrRuby::Nips::MetadataEvent.new(metadata)
+
+    event = instance.call
+    event[:pubkey] = @public_key
 
     build_event(event)
   end

--- a/lib/nostr_ruby/nips/base_event.rb
+++ b/lib/nostr_ruby/nips/base_event.rb
@@ -1,0 +1,11 @@
+module NostrRuby
+  module Nips
+    class BaseEvent
+      private
+
+      def now
+        Time.now.utc.to_i
+      end
+    end
+  end
+end

--- a/lib/nostr_ruby/nips/metadata_event.rb
+++ b/lib/nostr_ruby/nips/metadata_event.rb
@@ -1,0 +1,51 @@
+require_relative 'base_event'
+
+module NostrRuby
+  module Nips
+    # Metadata event (NIP-01 / NIP-24)
+    #
+    # @see https://github.com/nostr-protocol/nips/blob/master/01.md
+    # @see https://github.com/nostr-protocol/nips/blob/master/24.md
+    class MetadataEvent < BaseEvent
+      METADATA_KIND = 0
+
+      # @param metadata [Hash] list of nostr account metadata
+      # @option metadata [String] :name the "@" account name
+      # @option metadata [String] :display_name the friendly displayed name
+      # @option metadata [String] :about the profile description
+      # @option metadata [String] :picture the profile picture
+      # @option metadata [String] :banner the profile banner
+      # @option metadata [String] :nip05 the NIP-05 verification address
+      # @option metadata [String] :lud16 the lightning network address
+      # @option metadata [String] :website account website URL
+      def initialize(metadata = {})
+        super()
+
+        @metadata = metadata
+      end
+
+      def call
+        validate!
+
+        {
+          kind: METADATA_KIND,
+          tags: [],
+          content: metadata.to_json,
+          created_at: now
+        }
+      end
+
+      private
+
+      def validate!
+      end
+
+      def metadata
+        @metadata.slice(
+          :name, :display_name, :about, :picture,
+          :banner, :nip05, :lud16, :website
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is an experiment to extract the metadata event NIP into a dedicated class that could turn into a bigger refactoring where all NIPs will live in a dedicated class.

More fields are now handled by the metadata NIP (NIP-01 and NIP-24) such as `banner`, `display_name`, `lud16` and `website`.

> [!Caution]
> This is a breaking change from previous version as params are now passed as a keywords arguments
> instead of positionals arguments.

Here is an example of fake generated event using this refactoring:

<img width="836" alt="Capture d’écran 2024-01-12 à 20 34 28" src="https://github.com/dtonon/nostr-ruby/assets/5428510/04b7968e-cd24-40d4-aab0-7cf73a60469f">

&nbsp;

If this refactoring is accepted, I planned to keep contributing adding:
- the **NIP-52** Calendar event
- the **NIP-69** Poll event (not yet merged but implemented by Amethyst and Snort) 